### PR TITLE
Slash should be escaped in route values

### DIFF
--- a/ghapi/core.py
+++ b/ghapi/core.py
@@ -127,7 +127,7 @@ class GhApi(_GhObj):
         if not path.startswith(('http://', 'https://')):
             path = self.gh_host + path
         if route:
-            for k,v in route.items(): route[k] = quote(str(route[k]))
+            for k,v in route.items(): route[k] = quote(str(route[k]), safe='')
         return_json = ('json' in headers['Accept']) and (decode is True)
         debug = self.debug if self.debug else print_summary if os.getenv('GHAPI_DEBUG') else None
         res,self.recv_hdrs = urlsend(path, verb, headers=headers or None, decode=decode, debug=debug, return_headers=True,


### PR DESCRIPTION
Route dict is apparently used as a convenience to build URLs for parts between slashes. So it seems appropriate to escape slash (`/`) especially when values contain slashes on purpose.

NB: Not using routes with `GhApi(path)` by passing escaped string as path is an acceptable workaround but it does not work when leveraging `paged` method which either does not escape slash when passed as is, or escapes "%2F" when an escaped string is passed:

This does not work:

```
api = GhApi()
img_name = "ns/img"
img_versions = api('/orgs/{org}/packages/container/{img_name}/versions', 'GET', route=dict(org="org", img_name=img_name))
```

Working around works:

```
api = GhApi()
img_name = "ns/img"
img_versions = api('/orgs/{org}/packages/container/%s/versions' % urllib.parse.quote(img_name, safe=''), 'GET', route=dict(org="org"))
```

Using paged fails as endpoint does not exist when not escaped:

```
api = GhApi()
img_name = "ns/img"
img_versions_pages = paged(api.packages.get_all_package_versions_for_package_owned_by_org, org="org", package_type="container", package_name=img_name)
```

Using paged fails as  package does not exist when escaped

```
api = GhApi()
img_name = "ns/img"
img_versions_pages = paged(api.packages.get_all_package_versions_for_package_owned_by_org, org="org", package_type="container", package_name=urllib.parse.quote(img_name, safe=''))
```