### PR TITLE
deps: depend on `GitPython`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ py_versions = '2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3
 min_python = cfg['min_python']
 lic = licenses[cfg['license']]
 
-requirements = ['packaging']
+requirements = ['packaging', 'GitPython']
 if cfg.get('requirements'): requirements += cfg.get('requirements','').split()
 if cfg.get('pip_requirements'): requirements += cfg.get('pip_requirements','').split()
 dev_requirements = (cfg.get('dev_requirements') or '').split()


### PR DESCRIPTION
In a recent commit [1] an import for `git` was added without adding the appropriate dependency to `setup.py`. This means `GitPython` needs to be part of the requirements listed in `setup.py` for the package to function.

[1]: https://github.com/AnswerDotAI/ghapi/commit/6bc5d3cf99fcbff7c81e175e0e020f58d10c9978

---

I reported this earlier in #197. Testing this with a local install seems to work, at least superficially as there doesn't seem to be a test suite to run (maybe I'm missing something):

```console
$ git status
On branch git-dependency
nothing to commit, working tree clean
$ python3 -m venv venv                                                                                                               
$ venv/bin/pip install -e.
Obtaining file:///home/user/src/github.com/answerdotai/ghapi
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting packaging (from ghapi==1.0.8)
  Using cached packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Collecting GitPython (from ghapi==1.0.8)
  Using cached gitpython-3.1.45-py3-none-any.whl.metadata (13 kB)
Collecting fastcore>=1.7.2 (from ghapi==1.0.8)
  Using cached fastcore-1.8.8-py3-none-any.whl.metadata (3.7 kB)
Collecting gitdb<5,>=4.0.1 (from GitPython->ghapi==1.0.8)
  Using cached gitdb-4.0.12-py3-none-any.whl.metadata (1.2 kB)
Collecting smmap<6,>=3.0.1 (from gitdb<5,>=4.0.1->GitPython->ghapi==1.0.8)
  Using cached smmap-5.0.2-py3-none-any.whl.metadata (4.3 kB)
Using cached fastcore-1.8.8-py3-none-any.whl (79 kB)
Using cached gitpython-3.1.45-py3-none-any.whl (208 kB)
Using cached packaging-25.0-py3-none-any.whl (66 kB)
Using cached gitdb-4.0.12-py3-none-any.whl (62 kB)
Using cached smmap-5.0.2-py3-none-any.whl (24 kB)
Building wheels for collected packages: ghapi
  Building editable for ghapi (pyproject.toml) ... done
  Created wheel for ghapi: filename=ghapi-1.0.8-0.editable-py3-none-any.whl size=11663 sha256=6d7ea7b4698c3547e456a3ff383d61851d9c83ae35efaa90e6d47df0962398a8
  Stored in directory: /tmp/pip-ephem-wheel-cache-lflo6id_/wheels/32/cd/ad/c0c890acfadf10ff57da8068a6f0a5fec9deb139aa19ed5645
Successfully built ghapi
Installing collected packages: smmap, packaging, gitdb, fastcore, GitPython, ghapi
Successfully installed GitPython-3.1.45 fastcore-1.8.8 ghapi-1.0.8 gitdb-4.0.12 packaging-25.0 smmap-5.0.2

[notice] A new release of pip is available: 24.3.1 -> 25.2
[notice] To update, run: /home/user/src/github.com/answerdotai/ghapi/venv/bin/python3 -m pip install --upgrade pip
$ venv/bin/python3
Python 3.13.7 (main, Aug 14 2025, 00:00:00) [GCC 15.2.1 20250808 (Red Hat 15.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from ghapi.all import GhApi
>>> 

