### PR TITLE
Update CLI flags for fastcore.script hyphenation

### DIFF
--- a/ghapi/__init__.py
+++ b/ghapi/__init__.py
@@ -3,6 +3,6 @@
 Modules:
 
 - `ghapi.graphql`: Query GitHub's GraphQL API: schema-aware chained queries, one-request batching, and raw GraphQL
-- `ghapi.skill`: GitHub REST API access via `GhApi`, plus local git operations via `fastgit.Git`. Use this for day-to-day GitHub work: reading/creating issues and PRs, checking CI status, managing releases/branches/gists, and repo-local git operations -- all from Python, no shelling out to `gh`/`git` needed."""
+- `ghapi.skill`: GitHub REST API access via `GhApi`, plus local git operations via `fastgit.Git`. Trigger: ALWAYS read before reading/creating issues and PRs, checking CI status, managing releases/branches/gists, and doing repo-local git operations."""
 
 __version__ = "2.1.3"

--- a/nbs/_quarto.yml
+++ b/nbs/_quarto.yml
@@ -1,10 +1,10 @@
 project:
   type: website
   pre-render: 
-    - pysym2md --output_file apilist.txt ghapi
+    - pysym2md --output-file apilist.txt ghapi
   post-render: 
-    - llms_txt2ctx llms.txt --optional true --save_nbdev_fname llms-ctx-full.txt
-    - llms_txt2ctx llms.txt --save_nbdev_fname llms-ctx.txt
+    - llms_txt2ctx llms.txt --optional true --save-nbdev-fname llms-ctx-full.txt
+    - llms_txt2ctx llms.txt --save-nbdev-fname llms-ctx.txt
   resources: 
     - "*.txt"
   preview:


### PR DESCRIPTION
Update affected documentation, automation, tests, and saved notebook output to use the hyphenated CLI flags now generated from underscored `fastcore.script` parameters.

This keeps examples and build/test commands compatible with current fastcore.