### PR TITLE
Import APIError from fasttransport

### DIFF
--- a/ghapi/core.py
+++ b/ghapi/core.py
@@ -23,7 +23,7 @@ from fastspec.spec import SpecParser
 from fastspec.oapi import OpenAPIClient, OpFunc, SyncOpFunc
 from fasttransport.core import AsyncTransport, SyncTransport
 from .gh_spec import spec
-from fastspec.errors import APIError
+from fasttransport.errors import APIError
 
 import mimetypes,base64
 from collections import Counter

--- a/ghapi/page.py
+++ b/ghapi/page.py
@@ -11,7 +11,7 @@ __all__ = ['paged', 'parse_link_hdr', 'pages', 'sync_paged', 'sync_pages', 'Noti
 from fastcore.all import *
 from .core import *
 from .core import _age
-from fastspec.errors import APIError
+from fasttransport.errors import APIError
 
 import re, asyncio
 from datetime import datetime, timedelta, timezone

--- a/ghapi/skill.py
+++ b/ghapi/skill.py
@@ -90,7 +90,7 @@ Once the PR exists, the fork branch is the source of truth, and the local clone 
 - Results with tuned reprs (`read_issue`, `check_status`, `list_prs`, `gh_notifs`) display bare. Raw endpoint results don't, so when only confirmation matters (a `create_comment`, a `pulls.update`), assign the result to a variable and show one key (`r.html_url`, `r.state`) instead of displaying the whole payload.
 - A PR *is* an issue for general comments (`issues.list_comments`, not `pulls.*`) -- inline code-review comments are the separate `pulls.list_review_comments`.
 - Rate limits: register `limit_cb` on `GhApi(...)` to get called back whenever the remaining quota changes, or check `api.limit_rem` any time.
-- HTTP errors raise `fastspec.errors.APIError`, which carries `.status_code` and the endpoint called.
+- HTTP errors raise `fasttransport.errors.APIError`, which carries `.status_code` and the endpoint called.
 - `per_page` maxes out at 100; beyond that, use `paged`/`pages` rather than manually looping `page=`.
 - Per-call headers on named endpoints use `headers_=` (e.g. `await api.pulls.get(n, headers_={'Accept': 'application/vnd.github.v3.diff'})` for the raw diff); plain `headers=` is a kwarg only for direct `api(path, verb, ...)` calls.
 - `GITHUB_TOKEN` unset means unauthenticated (heavily rate-limited, no write access) -- `GhApi()` warns but doesn't raise.

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -36,7 +36,7 @@
     "from fastspec.oapi import OpenAPIClient, OpFunc, SyncOpFunc\n",
     "from fasttransport.core import AsyncTransport, SyncTransport\n",
     "from ghapi.gh_spec import spec\n",
-    "from fastspec.errors import APIError\n",
+    "from fasttransport.errors import APIError\n",
     "\n",
     "import mimetypes,base64\n",
     "from collections import Counter\n",

--- a/nbs/03_page.ipynb
+++ b/nbs/03_page.ipynb
@@ -31,7 +31,7 @@
     "from fastcore.all import *\n",
     "from ghapi.core import *\n",
     "from ghapi.core import _age\n",
-    "from fastspec.errors import APIError\n",
+    "from fasttransport.errors import APIError\n",
     "\n",
     "import re, asyncio\n",
     "from datetime import datetime, timedelta, timezone\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard", email = "info@fast.ai"}]
 keywords = ['github', 'api']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 5 - Production/Stable", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastcore>=2.2.7', 'fastspec>=0.2.1', 'tomli; python_version < "3.11"']
+dependencies = ['fastcore>=2.2.7', 'fastspec>=0.2.1', 'fasttransport>=0.0.2', 'tomli; python_version < "3.11"']
 
 [project.urls]
 Repository = "https://github.com/fastai/ghapi"


### PR DESCRIPTION
`APIError` now comes from `fasttransport.errors`, which is where the class lives after fastspec dropped it. Code catching `fastspec.errors.APIError` around these calls must catch `fasttransport.errors.APIError` instead. It is the same class, moved.